### PR TITLE
Allow skipping of automatic region replacement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ class ServerlessAWSPseudoParameters {
     this.hooks = {
       'before:deploy:deploy': this.addParameters.bind(this),
     };
+    this.skipRegionReplace = _.get(serverless.service, 'custom.pseudoParameters.skipRegionReplace', false)
   }
 
   addParameters() {
@@ -19,10 +20,15 @@ class ServerlessAWSPseudoParameters {
 
     this.serverless.cli.consoleLog(`${chalk.yellow.underline('AWS Pseudo Parameters')}`);
 
+    var skipRegionReplace = this.skipRegionReplace;
+    if (skipRegionReplace) {
+      console.info('Skipping automatic replacement of regions with account region!');
+    }
+
     // loop through all resources, and check all (string) properties for any #{AWS::}
     // reference. If found, replace the value with an Fn::Sub reference
     _.forEach(template.Resources, function(resource, identifier){
-      replaceChildNodes(resource.Properties, identifier);
+      replaceChildNodes(resource.Properties, identifier, skipRegionReplace);
     });
 
     function isDict(v) {
@@ -52,11 +58,11 @@ class ServerlessAWSPseudoParameters {
       return new RegExp(regions().join("|")).test(v);
     }
 
-    function replaceChildNodes(dictionary, name){
+    function replaceChildNodes(dictionary, name, skipRegionReplace) {
         _.forEach(dictionary, function(value, key){
 
-          // if a region name is mentioned, replace it with a reference
-          if(typeof value === 'string' && containsRegion(value)) {
+          // if a region name is mentioned, replace it with a reference (unless we are skipping automatic replacements)
+          if(typeof value === 'string' && !skipRegionReplace && containsRegion(value)) {
             var regionFinder = new RegExp(regions().join("|"));
             value = value.replace(regionFinder, '#{AWS::Region}');
           }
@@ -83,7 +89,7 @@ class ServerlessAWSPseudoParameters {
 
           // dicts and arrays need to be looped through
           if (isDict(value) || isArray(value)) {
-            dictionary[key] = replaceChildNodes(value, name + '::' + key);
+            dictionary[key] = replaceChildNodes(value, name + '::' + key, skipRegionReplace);
           }
 
         });

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,18 +17,19 @@ class ServerlessAWSPseudoParameters {
   addParameters() {
 
     const template = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const skipRegionReplace = this.skipRegionReplace;
+    const consoleLog = this.serverless.cli.consoleLog;
 
-    this.serverless.cli.consoleLog(`${chalk.yellow.underline('AWS Pseudo Parameters')}`);
+    consoleLog(`${chalk.yellow.underline('AWS Pseudo Parameters')}`);
 
-    var skipRegionReplace = this.skipRegionReplace;
     if (skipRegionReplace) {
-      console.info('Skipping automatic replacement of regions with account region!');
+      consoleLog('Skipping automatic replacement of regions with account region!');
     }
 
     // loop through all resources, and check all (string) properties for any #{AWS::}
     // reference. If found, replace the value with an Fn::Sub reference
     _.forEach(template.Resources, function(resource, identifier){
-      replaceChildNodes(resource.Properties, identifier, skipRegionReplace);
+      replaceChildNodes(resource.Properties, identifier);
     });
 
     function isDict(v) {
@@ -58,7 +59,7 @@ class ServerlessAWSPseudoParameters {
       return new RegExp(regions().join("|")).test(v);
     }
 
-    function replaceChildNodes(dictionary, name, skipRegionReplace) {
+    function replaceChildNodes(dictionary, name) {
         _.forEach(dictionary, function(value, key){
 
           // if a region name is mentioned, replace it with a reference (unless we are skipping automatic replacements)
@@ -82,14 +83,14 @@ class ServerlessAWSPseudoParameters {
               if (m) {
                 var msg = name + '::' + key + ' Replaced ' + chalk.yellow(m[1]) + ' with ' + chalk.yellow('${AWS::' + m[1] + '}');
                 // this.serverless.cli.consoleLog(message);
-                console.info('AWS Pseudo Parameter: ' + msg)
+                consoleLog('AWS Pseudo Parameter: ' + msg)
               }
             } while (m);
           }
 
           // dicts and arrays need to be looped through
           if (isDict(value) || isArray(value)) {
-            dictionary[key] = replaceChildNodes(value, name + '::' + key, skipRegionReplace);
+            dictionary[key] = replaceChildNodes(value, name + '::' + key);
           }
 
         });


### PR DESCRIPTION
If you define in serverless.yaml:

```yaml
    custom:
       pseudoParameters:
          skipRegionReplace: true
```

You can skip the automatic replacement of anything that looks like a
region with AWS::Region.

This is necessary for example when working with Cloudfront. Cloudfront
only works with ACM certificates that are in us-east-1. So if we replace
with anything else (e.g us-west-2) you will break the cloudfront distribution.