### PR TITLE
Remove 3rd party dependencies

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,5 @@
 'use strict';
 
-const _ = require('lodash');
-const chalk = require('chalk');
-
-
 class ServerlessAWSPseudoParameters {
   constructor(serverless, options) {
     this.serverless = serverless;
@@ -11,16 +7,16 @@ class ServerlessAWSPseudoParameters {
     this.hooks = {
       'before:deploy:deploy': this.addParameters.bind(this),
     };
-    this.skipRegionReplace = _.get(serverless.service, 'custom.pseudoParameters.skipRegionReplace', false)
+    this.skipRegionReplace = get(serverless.service, 'custom.pseudoParameters.skipRegionReplace', false)
   }
 
   addParameters() {
 
-    const template = this.serverless.service.provider.compiledCloudFormationTemplate;
+    const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
     const skipRegionReplace = this.skipRegionReplace;
     const consoleLog = this.serverless.cli.consoleLog;
 
-    consoleLog(`${chalk.yellow.underline('AWS Pseudo Parameters')}`);
+    consoleLog(yellow(underline('AWS Pseudo Parameters')));
 
     if (skipRegionReplace) {
       consoleLog('Skipping automatic replacement of regions with account region!');
@@ -28,12 +24,10 @@ class ServerlessAWSPseudoParameters {
 
     // loop through all resources, and check all (string) properties for any #{AWS::}
     // reference. If found, replace the value with an Fn::Sub reference
-    _.forEach(template.Resources, function(resource, identifier){
-      replaceChildNodes(resource.Properties, identifier);
-    });
+    Object.keys(resources).forEach(identifier => replaceChildNodes(resources[identifier].Properties, identifier));
 
     function isDict(v) {
-      return typeof v==='object' && v!==null && !(v instanceof Array) && !(v instanceof Date);
+      return typeof v === 'object' && v !== null && !(v instanceof Array) && !(v instanceof Date);
     }
 
     function isArray(v) {
@@ -60,45 +54,53 @@ class ServerlessAWSPseudoParameters {
     }
 
     function replaceChildNodes(dictionary, name) {
-        _.forEach(dictionary, function(value, key){
+      Object.keys(dictionary).forEach((key) => {
 
-          // if a region name is mentioned, replace it with a reference (unless we are skipping automatic replacements)
-          if(typeof value === 'string' && !skipRegionReplace && containsRegion(value)) {
-            var regionFinder = new RegExp(regions().join("|"));
-            value = value.replace(regionFinder, '#{AWS::Region}');
+        let value = dictionary[key];
+        // if a region name is mentioned, replace it with a reference (unless we are skipping automatic replacements)
+        if (typeof value === 'string' && !skipRegionReplace && containsRegion(value)) {
+          const regionFinder = new RegExp(regions().join("|"));
+          value = value.replace(regionFinder, '#{AWS::Region}');
+        }
+
+        // we only want to possibly replace strings with an Fn::Sub
+        if (typeof value === 'string' && value.search(/#{AWS::([a-zA-Z]+)}/) >= 0) {
+          consoleLog('replacing line: ' + value);
+          const aws_regex = /#{AWS::([a-zA-Z]+)}/g;
+
+          dictionary[key] = {
+            "Fn::Sub": value.replace(aws_regex, '${AWS::$1}')
+          };
+
+          // do some fancy logging
+          let m = aws_regex.exec(value);
+          while (m) {
+            consoleLog('AWS Pseudo Parameter: ' + name + '::' + key + ' Replaced ' + yellow(m[1]) + ' with ' + yellow('${AWS::' + m[1] + '}'));
+            m = aws_regex.exec(value);
           }
+        }
 
-          // we only want to possibly replace strings with an Fn::Sub
-          if(typeof value === 'string' && value.search(/#{AWS::([a-zA-Z]+)}/) >= 0) {
-            var aws_regex = /#{AWS::([a-zA-Z]+)}/g;
-            var m;
+        // dicts and arrays need to be looped through
+        if (isDict(value) || isArray(value)) {
+          dictionary[key] = replaceChildNodes(value, name + '::' + key);
+        }
 
-            dictionary[key] = {
-              "Fn::Sub": value.replace(aws_regex, '${AWS::$1}')
-            }
+      });
+      return dictionary;
+    }
 
-            // do some fancy logging
-            do {
-              var m = aws_regex.exec(value);
-              if (m) {
-                var msg = name + '::' + key + ' Replaced ' + chalk.yellow(m[1]) + ' with ' + chalk.yellow('${AWS::' + m[1] + '}');
-                // this.serverless.cli.consoleLog(message);
-                consoleLog('AWS Pseudo Parameter: ' + msg)
-              }
-            } while (m);
-          }
+    function yellow(str) {
+      return '\u001B[33m' + str + '\u001B[39m';
+    }
 
-          // dicts and arrays need to be looped through
-          if (isDict(value) || isArray(value)) {
-            dictionary[key] = replaceChildNodes(value, name + '::' + key);
-          }
-
-        });
-        return dictionary;
-      }
-
+    function underline(str) {
+      return '\u001B[4m' + str + '\u001B[24m';
+    }
   }
+}
 
+function get(obj, path, def) {
+  return path.split('.').filter(Boolean).every(step => !(step && (obj = obj[step]) === undefined)) ? obj : def;
 }
 
 module.exports = ServerlessAWSPseudoParameters;

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,6 @@ class ServerlessAWSPseudoParameters {
 
         // we only want to possibly replace strings with an Fn::Sub
         if (typeof value === 'string' && value.search(/#{AWS::([a-zA-Z]+)}/) >= 0) {
-          consoleLog('replacing line: ' + value);
           const aws_regex = /#{AWS::([a-zA-Z]+)}/g;
 
           dictionary[key] = {

--- a/package.json
+++ b/package.json
@@ -7,8 +7,5 @@
     "git": "https://github.com/svdgraaf/serverless-pseudo-parameters"
   },
   "main": "lib/index.js",
-  "dependencies": {
-    "lodash": "^4.13.1",
-    "chalk": "^1.1.1"
-  }
+  "dependencies": {}
 }


### PR DESCRIPTION
Removed dependencies on lodash and chalk

Uses Object.keys.forEach and a simplified get in lieu of lodash forEach and get.
Uses local formatting functions for yellow and underline in lieu of importing 8+ packages. 