### PR TITLE
Replaces pseudo parameters after custom resources are merged

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -5,7 +5,7 @@ class ServerlessAWSPseudoParameters {
     this.serverless = serverless;
     this.options = options;
     this.hooks = {
-      'before:aws:package:finalize:mergeCustomProviderResources': this.addParameters.bind(this),
+      'after:aws:package:finalize:mergeCustomProviderResources': this.addParameters.bind(this),
     };
     this.skipRegionReplace = get(serverless.service, 'custom.pseudoParameters.skipRegionReplace', false)
   }


### PR DESCRIPTION
This still allows the pseudo parameters to be replaced in the "package" step, just after any custom resources are merged.

Good reference for available lifecycle events: https://gist.github.com/HyperBrain/50d38027a8f57778d5b0f135d80ea406

Fixes #10 