### PR TITLE
Cover more sections of the template

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ class ServerlessAWSPseudoParameters {
 
   addParameters() {
 
-    const resources = this.serverless.service.provider.compiledCloudFormationTemplate.Resources;
+    const template = this.serverless.service.provider.compiledCloudFormationTemplate;
     const skipRegionReplace = this.skipRegionReplace;
     const consoleLog = this.serverless.cli.consoleLog;
 
@@ -22,13 +22,12 @@ class ServerlessAWSPseudoParameters {
       consoleLog('Skipping automatic replacement of regions with account region!');
     }
 
-    // loop through all resources, and check all (string) properties for any #{AWS::}
+    // loop through the entire template, and check all (string) properties for any #{AWS::}
     // reference. If found, replace the value with an Fn::Sub reference
-    Object.keys(resources).forEach(identifier => {
-      if ("Properties" in resources[identifier]) {
-          replaceChildNodes(resources[identifier].Properties, identifier)
-      }
+    Object.keys(template).forEach(identifier => {
+      replaceChildNodes(template[identifier], identifier)
     });
+
 
     function isDict(v) {
       return typeof v === 'object' && v !== null && !(v instanceof Array) && !(v instanceof Date);

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -71,5 +71,71 @@ describe('Plugin', () => {
 
   });
 
+  describe('using pseudo parameters in the outputs', () => {
+    let serverlessPseudoParamsPlugin;
+    let resultTemplate;
+
+    beforeEach(() => {
+      const serverless = {
+        cli: {
+          log: () => {},
+          consoleLog: () => {}
+        },
+        service: {
+          provider: {
+            compiledCloudFormationTemplate: {},
+          }
+        },
+      };
+      serverless.service.provider.compiledCloudFormationTemplate = { Outputs: {
+        acmeOutput: {
+          AccountId: "#{AWS::AccountId}",
+          Region: "#{AWS::Region}",
+          NotificationARNs: "#{AWS::NotificationARNs}",
+          NoValue: "#{AWS::NoValue}",
+          Partition: "#{AWS::Partition}",
+          StackId: "#{AWS::StackId}",
+          StackName: "#{AWS::StackName}",
+          URLSuffix: "#{AWS::URLSuffix}",
+        }
+      } };
+      serverlessPseudoParamsPlugin = new Plugin(serverless);
+      serverlessPseudoParamsPlugin.serverless.service.service = 'foo-service';
+      serverlessPseudoParamsPlugin.addParameters();
+      resultTemplate = serverlessPseudoParamsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
+      expect(Object.keys(resultTemplate.Outputs.acmeOutput).length).toEqual(8);
+    });
+
+    it('replaces #{AWS::[VAR]} with the correct CF pseudo parameter', () => {
+      expect(Object.keys(resultTemplate.Outputs.acmeOutput).length).toEqual(8);
+    });
+
+    it('replaces #{AWS::AccountId} with the ${AWS::AccountId} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.AccountId).toEqual({ 'Fn::Sub': '${AWS::AccountId}' });
+    });
+    it('replaces #{AWS::Region} with the ${AWS::Region} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.Region).toEqual({ 'Fn::Sub': '${AWS::Region}' });
+    });
+    it('replaces #{AWS::NotificationARNs} with the ${AWS::NotificationARNs} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.NotificationARNs).toEqual({ 'Fn::Sub': '${AWS::NotificationARNs}' });
+    });
+    it('replaces #{AWS::NoValue} with the ${AWS::NoValue} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.NoValue).toEqual({ 'Fn::Sub': '${AWS::NoValue}' });
+    });
+    it('replaces #{AWS::Partition} with the ${AWS::Partition} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.Partition).toEqual({ 'Fn::Sub': '${AWS::Partition}' });
+    });
+    it('replaces #{AWS::StackId} with the ${AWS::StackId} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.StackId).toEqual({ 'Fn::Sub': '${AWS::StackId}' });
+    });
+    it('replaces #{AWS::StackName} with the ${AWS::StackName} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.StackName).toEqual({ 'Fn::Sub': '${AWS::StackName}' });
+    });
+    it('replaces #{AWS::URLSuffix} with the ${AWS::URLSuffix} pseudo parameter', () => {
+      expect(resultTemplate.Outputs.acmeOutput.URLSuffix).toEqual({ 'Fn::Sub': '${AWS::URLSuffix}' });
+    });
+  })
+
+
 
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1845,14 +1845,6 @@
             }
           }
         },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
-        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -1861,6 +1853,14 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
+          }
+        },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -3993,15 +3993,6 @@
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
       "dev": true
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4020,6 +4011,15 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {


### PR DESCRIPTION
At present the plugin only replaces pseudo parameters in the Resources section of the template.

#12 suggests adding support for replacing pseudo parameters in more sections.

This extends the existing recursive parsing of the template to perform replacement across the entire template, thus replacing parameters across all sections.

It is possible this goes too far in replacing the parameters, so it could be revised to only perform replacement in certain sections.

This also adds tests for the Outputs section of the template.