### PR TITLE
Add allowReferences option and update AWS regions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,12 +8,14 @@ class ServerlessAWSPseudoParameters {
       'after:aws:package:finalize:mergeCustomProviderResources': this.addParameters.bind(this),
     };
     this.skipRegionReplace = get(serverless.service, 'custom.pseudoParameters.skipRegionReplace', false)
+    this.allowReferences = get(serverless.service, 'custom.pseudoParameters.allowReferences', false)
   }
 
   addParameters() {
 
     const template = this.serverless.service.provider.compiledCloudFormationTemplate;
     const skipRegionReplace = this.skipRegionReplace;
+    const allowReferences = this.allowReferences;
     const consoleLog = this.serverless.cli.consoleLog;
 
     consoleLog(yellow(underline('AWS Pseudo Parameters')));
@@ -39,16 +41,21 @@ class ServerlessAWSPseudoParameters {
 
     function regions() {
       return [
-        'eu-west-1',
-        'eu-west-2',
-        'us-east-1',
-        'us-east-2',
-        'us-west-2',
-        'ap-south-1',
-        'ap-northeast-2',
-        'ap-southeast-2',
-        'ap-northeast-1',
-        'eu-central-1'
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2"
       ]
     }
 
@@ -66,18 +73,23 @@ class ServerlessAWSPseudoParameters {
           value = value.replace(regionFinder, '#{AWS::Region}');
         }
 
-        // we only want to possibly replace strings with an Fn::Sub
-        if (typeof value === 'string' && value.search(/#{AWS::([a-zA-Z]+)}/) >= 0) {
-          const aws_regex = /#{AWS::([a-zA-Z]+)}/g;
+        var aws_regex;
+        if (allowReferences) {
+          aws_regex = /#{([^}]+)}/g;
+        } else {
+          aws_regex = /#{(AWS::[a-zA-Z]+)}/g
+        }
 
+        // we only want to possibly replace strings with an Fn::Sub
+        if (typeof value === 'string' && value.search(aws_regex) >= 0) {
           dictionary[key] = {
-            "Fn::Sub": value.replace(aws_regex, '${AWS::$1}')
+            "Fn::Sub": value.replace(aws_regex, '${$1}')
           };
 
           // do some fancy logging
           let m = aws_regex.exec(value);
           while (m) {
-            consoleLog('AWS Pseudo Parameter: ' + name + '::' + key + ' Replaced ' + yellow(m[1]) + ' with ' + yellow('${AWS::' + m[1] + '}'));
+            consoleLog('AWS Pseudo Parameter: ' + name + '::' + key + ' Replaced ' + yellow(m[1]) + ' with ' + yellow('${' + m[1] + '}'));
             m = aws_regex.exec(value);
           }
         }

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -30,6 +30,7 @@ describe('Plugin', () => {
             StackId: "#{AWS::StackId}",
             StackName: "#{AWS::StackName}",
             URLSuffix: "#{AWS::URLSuffix}",
+            Reference: "#{SomeResource}",
           }
         }
       } };
@@ -37,11 +38,11 @@ describe('Plugin', () => {
       serverlessPseudoParamsPlugin.serverless.service.service = 'foo-service';
       serverlessPseudoParamsPlugin.addParameters();
       resultTemplate = serverlessPseudoParamsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
-      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(8);
+      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(9);
     });
 
     it('replaces #{AWS::[VAR]} with the correct CF pseudo parameter', () => {
-      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(8);
+      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(9);
     });
 
     it('replaces #{AWS::AccountId} with the ${AWS::AccountId} pseudo parameter', () => {
@@ -67,6 +68,59 @@ describe('Plugin', () => {
     });
     it('replaces #{AWS::URLSuffix} with the ${AWS::URLSuffix} pseudo parameter', () => {
       expect(resultTemplate.Resources.acmeResource.Properties.URLSuffix).toEqual({ 'Fn::Sub': '${AWS::URLSuffix}' });
+    });
+    it('does not replace #{SomeResource}', () => {
+      expect(resultTemplate.Resources.acmeResource.Properties.Reference).toEqual("#{SomeResource}");
+    });
+
+  });
+
+  describe('Using pseudo parameters with allowReferences', () => {
+    let serverlessPseudoParamsPlugin;
+    let resultTemplate;
+
+    beforeEach(() => {
+      const serverless = {
+        cli: {
+          log: () => {},
+          consoleLog: () => {}
+        },
+        service: {
+          provider: {
+            compiledCloudFormationTemplate: {},
+          },
+          custom: {
+            pseudoParameters: {
+              allowReferences: true
+            }
+          }
+        },
+      };
+      serverless.service.provider.compiledCloudFormationTemplate = { Resources: {
+        acmeResource: {
+          Type: "AWS::Foo::Bar",
+          Properties: {
+            AccountId: "#{AWS::AccountId}",
+            Reference: "#{SomeResource}",
+          }
+        }
+      } };
+      serverlessPseudoParamsPlugin = new Plugin(serverless);
+      serverlessPseudoParamsPlugin.serverless.service.service = 'foo-service';
+      serverlessPseudoParamsPlugin.addParameters();
+      resultTemplate = serverlessPseudoParamsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
+      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(2);
+    });
+
+    it('replaces #{AWS::[VAR]} with the correct CF pseudo parameter', () => {
+      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(2);
+    });
+
+    it('replaces #{AWS::AccountId} with the ${AWS::AccountId} pseudo parameter', () => {
+      expect(resultTemplate.Resources.acmeResource.Properties.AccountId).toEqual({ 'Fn::Sub': '${AWS::AccountId}' });
+    });
+    it('replaces #{SomeResource} with ${SomeResource}', () => {
+      expect(resultTemplate.Resources.acmeResource.Properties.Reference).toEqual({ 'Fn::Sub': '${SomeResource}' });
     });
 
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-pseudo-parameters",
-  "version": "1.4.2",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
Since `serverless-pseudo-parameters` uses `Fn::Sub` for pseudo-parameter substitution, we can make use of some other features of `Fn::Sub` namely referencing CloudFormation resources!

Setting the following in `serverless.yml`:
```
custom:
  pseudoParameters:
    allowReferences: true
```

Enables:
  * using `#{MyResource}` to be rewritten to `${MyResource}`, which is roughly equivalent to `{"Ref": "MyResource"}`,
  * using `#{MyResource.Arn}` to be rewritten to `${MyResource.Arn}`, which is roughly equivalent to `{"Fn::GetAtt": ["MyResource", "Arn"]}`.
