### PR TITLE
If string is already in Fn::Sub don't add another Fn::Sub

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -82,9 +82,16 @@ class ServerlessAWSPseudoParameters {
 
         // we only want to possibly replace strings with an Fn::Sub
         if (typeof value === 'string' && value.search(aws_regex) >= 0) {
-          dictionary[key] = {
-            "Fn::Sub": value.replace(aws_regex, '${$1}')
-          };
+
+          let replacedString = value.replace(aws_regex, '${$1}');
+
+          if (key === 'Fn::Sub') {
+            dictionary[key] = replacedString;
+          } else {
+            dictionary[key] = {
+              "Fn::Sub": replacedString
+            };
+          }
 
           // do some fancy logging
           let m = aws_regex.exec(value);

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -31,6 +31,9 @@ describe('Plugin', () => {
             StackName: "#{AWS::StackName}",
             URLSuffix: "#{AWS::URLSuffix}",
             Reference: "#{SomeResource}",
+            Substitution: {
+              "Fn::Sub": "#{SomeResource}"
+            }
           }
         }
       } };
@@ -71,6 +74,9 @@ describe('Plugin', () => {
     });
     it('replaces #{SomeResource}', () => {
       expect(resultTemplate.Resources.acmeResource.Properties.Reference).toEqual({ 'Fn::Sub': '${SomeResource}'});
+    });
+    it('should not add Fn::Sub to items with Fn::Sub already', () => {
+      expect(resultTemplate.Resources.acmeResource.Properties.Substitution).toEqual({ 'Fn::Sub': '${SomeResource}'});
     });
 
   });


### PR DESCRIPTION
Hi,

Came across this issue today when I used #{Stage} as my stage in Serverless. It seemed to add an extra Fn::Sub which broke the CF template. This is a patch to fix it.

Good work on the plugin btw, been using it a lot.