### PR TITLE
Support serverless variables syntax `${}`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,23 @@ class ServerlessAWSPseudoParameters {
     this.allowReferences = get(serverless.service, 'custom.pseudoParameters.allowReferences', true);
     this.colors = get(this.serverless,'processedInput.options.color', true);
     this.debug = this.options.debug || process.env.SLS_DEBUG;
+
+    // Override the variable resolver to declare our own variables
+    const delegate = serverless.variables
+        .getValueFromSource.bind(serverless.variables);
+
+    serverless.variables.getValueFromSource = (variableString) => {
+      if (variableString.startsWith('AWS::')) {
+        return '#{' + variableString + '}';
+      }
+      if (variableString.startsWith('ref:')) {
+        return '#{' + variableString.replace('ref:', '') + '}';
+      }
+      if (variableString.startsWith('getatt:')) {
+        return '#{' + variableString.replace('getatt:', '') + '}';
+      }
+      return delegate(variableString);
+    }
   }
 
   addParameters() {


### PR DESCRIPTION
This is a follow up from https://github.com/serverless/serverless/issues/3184#issuecomment-665756516

With a little changes, I managed to make this plugin support the `${}` syntax of Serverless (instead of `#{}`). Here is an example:

```yaml
functions:
    hello:
        handler: handler.hello
        environment:
            # We can reference `AWS::` variables
            REGION: ${AWS::Region}

            # We can use !Ref inline via the `ref:` prefix:
            BUCKET_NAME: ${ref:MyBucket}

            # We can use !GetAtt inline via the `getatt:` prefix:
            BUCKET_URL: 'https://${getatt:MyBucket.DomainName}'

            # We can use mix all that together in a string:
            REGIONAL_URL: 'https://${ref:MyBucket}.s3.${AWS::Region}.amazonaws.com'

            # We can also mix all of that with actual serverless variables (e.g. `${self:provider.stage}`)

resources:
    Resources:
        MyBucket:
            Type: AWS::S3::Bucket
```


I defined the following variables:

- `${AWS::xxx}` is compiled to `#{AWS::xxx}`
- `${ref::xxx}` is compiled to `#{xxx}`
- `${getatt::xxx.yyy}` is compiled to `#{xxx.yyy}`

I am opening this PR first to get some feedback and see if we should proceed with this. I like the fact that it is backward compatible, yet opens the possibility to switch to an entirely new syntax.

WDYT?