### PR TITLE
Add Support for Invoke Local and Deploy Function Commands

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,0 +1,4 @@
+module.exports = {
+  singleQuote: true,
+  trailingComma: 'none'
+};

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: node_js
 node_js:
-  - "7"
-  - "8"
-  - "lts/*"
+  - '7'
+  - '8'
+  - 'lts/*'
 
 install:
   - npm install
@@ -12,4 +12,4 @@ script:
 
 cache:
   directories:
-    - "node_modules"
+    - 'node_modules'

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ Escaping tokens
 -----------------------------------
 You can prevent tokens from being replaced by escaping with the `@` character after the token's hash character
 ```yaml
-DynamoDBInputS3OutputHive: 
+DynamoDBInputS3OutputHive:
   Type: AWS::DataPipeline::Pipeline
   Properties:
   	PipelineObjects:

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,27 +1,27 @@
-"use strict";
+'use strict';
 
 class ServerlessAWSPseudoParameters {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
     this.hooks = {
-      "invoke:local:loadEnvVars": this.invokeLocal.bind(this),
-      "deploy:function:initialize": this.deployFunction.bind(this),
-      "after:aws:package:finalize:mergeCustomProviderResources": this.addParameters.bind(
+      'invoke:local:loadEnvVars': this.invokeLocal.bind(this),
+      'deploy:function:initialize': this.deployFunction.bind(this),
+      'after:aws:package:finalize:mergeCustomProviderResources': this.addParameters.bind(
         this
-      ),
+      )
     };
     this.skipRegionReplace = get(
       serverless.service,
-      "custom.pseudoParameters.skipRegionReplace",
+      'custom.pseudoParameters.skipRegionReplace',
       true
     );
     this.allowReferences = get(
       serverless.service,
-      "custom.pseudoParameters.allowReferences",
+      'custom.pseudoParameters.allowReferences',
       true
     );
-    this.colors = get(this.serverless, "processedInput.options.color", true);
+    this.colors = get(this.serverless, 'processedInput.options.color', true);
     this.debug = this.options.debug || process.env.SLS_DEBUG;
   }
 
@@ -30,7 +30,7 @@ class ServerlessAWSPseudoParameters {
   }
 
   async runtimeResolveAWSVariables() {
-    let stringifiedFunctionObject = JSON.stringify(
+    const stringifiedFunctionObject = JSON.stringify(
       this.serverless.processedInput.options.functionObj
     );
     // Resolve parameters
@@ -52,28 +52,30 @@ class ServerlessAWSPseudoParameters {
               this.serverless.processedInput.region ||
               this.serverless.service.provider.region;
             switch (match) {
-              case "#{AWS::Region}":
+              case '#{AWS::Region}':
                 return {
-                  [match]: region,
+                  [match]: region
                 };
-              case "#{AWS::AccountId}":
+              case '#{AWS::AccountId}':
                 const sts = new this.serverless.providers.aws.sdk.STS();
                 const { Account } = await sts.getCallerIdentity({}).promise();
                 return { [match]: Account };
-              case "#{AWS::Partition}":
+              case '#{AWS::Partition}':
                 if (/^us\-gov/.test(region)) {
-                  return { [match]: "aws-us-gov" };
+                  return { [match]: 'aws-us-gov' };
                 } else if (/^cn\-/.test(region)) {
-                  return { [match]: "aws-cn" };
+                  return { [match]: 'aws-cn' };
                 }
-                return { [match]: "aws" };
-              case "#{AWS::NoValue}":
+                return { [match]: 'aws' };
+              case '#{AWS::NoValue}':
                 return { [match]: undefined };
-              case "#{AWS::StackName}":
+              case '#{AWS::NotificationARNs}':
+                throw new Error('#{AWS::NotificationARNs} not implemented');
+              case '#{AWS::StackName}':
                 return {
-                  [match]: this.serverless.providers.aws.naming.getStackName(),
+                  [match]: this.serverless.providers.aws.naming.getStackName()
                 };
-              case "#{AWS::StackId}":
+              case '#{AWS::StackId}':
                 const cloudformation = new this.serverless.providers.aws.sdk.CloudFormation(
                   { region }
                 );
@@ -82,7 +84,7 @@ class ServerlessAWSPseudoParameters {
                 do {
                   const {
                     StackSummaries,
-                    NextToken,
+                    NextToken
                   } = await cloudformation
                     .listStacks({ NextToken: nextTokenListStacks })
                     .promise();
@@ -99,13 +101,13 @@ class ServerlessAWSPseudoParameters {
                   }
                 } while (nextTokenListStacks);
                 return {
-                  [match]: stackId,
+                  [match]: stackId
                 };
-              case "#{AWS::URLSuffix}":
+              case '#{AWS::URLSuffix}':
                 if (/^cn\-/.test(region)) {
-                  return { [match]: "amazonaws.com.cn" };
+                  return { [match]: 'amazonaws.com.cn' };
                 }
-                return { [match]: "amazonaws.com" };
+                return { [match]: 'amazonaws.com' };
               default:
                 return { [match]: match };
             }
@@ -148,11 +150,11 @@ class ServerlessAWSPseudoParameters {
     const consoleLog = this.serverless.cli.consoleLog;
     const awsRegex = this.awsRegex;
 
-    if (debug) consoleLog(yellow(underline("AWS Pseudo Parameters")));
+    if (debug) consoleLog(yellow(underline('AWS Pseudo Parameters')));
 
     if (skipRegionReplace && debug) {
       consoleLog(
-        "Skipping automatic replacement of regions with account region!"
+        'Skipping automatic replacement of regions with account region!'
       );
     }
 
@@ -164,7 +166,7 @@ class ServerlessAWSPseudoParameters {
 
     function isDict(v) {
       return (
-        typeof v === "object" &&
+        typeof v === 'object' &&
         v !== null &&
         !(v instanceof Array) &&
         !(v instanceof Date)
@@ -172,31 +174,31 @@ class ServerlessAWSPseudoParameters {
     }
 
     function isArray(v) {
-      return Object.prototype.toString.call(v) === "[object Array]";
+      return Object.prototype.toString.call(v) === '[object Array]';
     }
 
     function regions() {
       return [
-        "ap-northeast-1",
-        "ap-northeast-2",
-        "ap-south-1",
-        "ap-southeast-1",
-        "ap-southeast-2",
-        "ca-central-1",
-        "eu-central-1",
-        "eu-west-1",
-        "eu-west-2",
-        "eu-west-3",
-        "sa-east-1",
-        "us-east-1",
-        "us-east-2",
-        "us-west-1",
-        "us-west-2",
+        'ap-northeast-1',
+        'ap-northeast-2',
+        'ap-south-1',
+        'ap-southeast-1',
+        'ap-southeast-2',
+        'ca-central-1',
+        'eu-central-1',
+        'eu-west-1',
+        'eu-west-2',
+        'eu-west-3',
+        'sa-east-1',
+        'us-east-1',
+        'us-east-2',
+        'us-west-1',
+        'us-west-2'
       ];
     }
 
     function containsRegion(v) {
-      return new RegExp(regions().join("|")).test(v);
+      return new RegExp(regions().join('|')).test(v);
     }
 
     function replaceChildNodes(dictionary, name) {
@@ -204,25 +206,25 @@ class ServerlessAWSPseudoParameters {
         let value = dictionary[key];
         // if a region name is mentioned, replace it with a reference (unless we are skipping automatic replacements)
         if (
-          typeof value === "string" &&
+          typeof value === 'string' &&
           !skipRegionReplace &&
           containsRegion(value)
         ) {
-          const regionFinder = new RegExp(regions().join("|"));
-          value = value.replace(regionFinder, "#{AWS::Region}");
+          const regionFinder = new RegExp(regions().join('|'));
+          value = value.replace(regionFinder, '#{AWS::Region}');
         }
 
         const aws_regex = awsRegex(allowReferences);
 
         // we only want to possibly replace strings with an Fn::Sub
-        if (typeof value === "string" && value.search(aws_regex) >= 0) {
-          let replacedString = value.replace(aws_regex, "${$1}");
+        if (typeof value === 'string' && value.search(aws_regex) >= 0) {
+          let replacedString = value.replace(aws_regex, '${$1}');
 
-          if (key === "Fn::Sub") {
+          if (key === 'Fn::Sub') {
             dictionary[key] = replacedString;
           } else {
             dictionary[key] = {
-              "Fn::Sub": replacedString,
+              'Fn::Sub': replacedString
             };
           }
 
@@ -231,14 +233,14 @@ class ServerlessAWSPseudoParameters {
             let m = aws_regex.exec(value);
             while (m) {
               consoleLog(
-                "AWS Pseudo Parameter: " +
+                'AWS Pseudo Parameter: ' +
                   name +
-                  "::" +
+                  '::' +
                   key +
-                  " Replaced " +
+                  ' Replaced ' +
                   yellow(m[1]) +
-                  " with " +
-                  yellow("${" + m[1] + "}")
+                  ' with ' +
+                  yellow('${' + m[1] + '}')
               );
               m = aws_regex.exec(value);
             }
@@ -246,26 +248,26 @@ class ServerlessAWSPseudoParameters {
         }
 
         var escaped_regex = /#@{([^}]+)}/g;
-        if (typeof value === "string" && value.search(escaped_regex) >= 0) {
-          let replacedString = value.replace(escaped_regex, "#{$1}");
+        if (typeof value === 'string' && value.search(escaped_regex) >= 0) {
+          let replacedString = value.replace(escaped_regex, '#{$1}');
           dictionary[key] = replacedString;
         }
 
         // dicts and arrays need to be looped through
         if (isDict(value) || isArray(value)) {
-          dictionary[key] = replaceChildNodes(value, name + "::" + key);
+          dictionary[key] = replaceChildNodes(value, name + '::' + key);
         }
       });
       return dictionary;
     }
 
     function yellow(str) {
-      if (colors) return "\u001B[33m" + str + "\u001B[39m";
+      if (colors) return '\u001B[33m' + str + '\u001B[39m';
       return str;
     }
 
     function underline(str) {
-      if (colors) return "\u001B[4m" + str + "\u001B[24m";
+      if (colors) return '\u001B[4m' + str + '\u001B[24m';
       return str;
     }
   }
@@ -273,7 +275,7 @@ class ServerlessAWSPseudoParameters {
 
 function get(obj, path, def) {
   return path
-    .split(".")
+    .split('.')
     .filter(Boolean)
     .every((step) => !(step && (obj = obj[step]) === undefined))
     ? obj

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,99 +1,228 @@
-'use strict';
+"use strict";
 
 class ServerlessAWSPseudoParameters {
   constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options || {};
     this.hooks = {
-      'after:aws:package:finalize:mergeCustomProviderResources': this.addParameters.bind(this)
+      "invoke:local:loadEnvVars": this.invokeLocal.bind(this),
+      "deploy:function:initialize": this.deployFunction.bind(this),
+      "after:aws:package:finalize:mergeCustomProviderResources": this.addParameters.bind(
+        this
+      ),
     };
-    this.skipRegionReplace = get(serverless.service, 'custom.pseudoParameters.skipRegionReplace', true);
-    this.allowReferences = get(serverless.service, 'custom.pseudoParameters.allowReferences', true);
-    this.colors = get(this.serverless,'processedInput.options.color', true);
+    this.skipRegionReplace = get(
+      serverless.service,
+      "custom.pseudoParameters.skipRegionReplace",
+      true
+    );
+    this.allowReferences = get(
+      serverless.service,
+      "custom.pseudoParameters.allowReferences",
+      true
+    );
+    this.colors = get(this.serverless, "processedInput.options.color", true);
     this.debug = this.options.debug || process.env.SLS_DEBUG;
   }
 
-  addParameters() {
+  awsRegex(allowReferences) {
+    return allowReferences ? /#{([^}]+)}/g : /#{(AWS::[a-zA-Z]+)}/g;
+  }
 
-    const template = this.serverless.service.provider.compiledCloudFormationTemplate;
+  async runtimeResolveAWSVariables() {
+    let stringifiedFunctionObject = JSON.stringify(
+      this.serverless.processedInput.options.functionObj
+    );
+    // Resolve parameters
+    const resolvedVariables = (
+      await Promise.all(
+        (
+          stringifiedFunctionObject.match(
+            this.awsRegex(this.allowReferences)
+          ) || []
+        )
+          .reduce((acc, match) => {
+            if (!acc.includes(match)) {
+              acc.push(match);
+            }
+            return acc;
+          }, [])
+          .map(async (match) => {
+            const region =
+              this.serverless.processedInput.region ||
+              this.serverless.service.provider.region;
+            switch (match) {
+              case "#{AWS::Region}":
+                return {
+                  [match]: region,
+                };
+              case "#{AWS::AccountId}":
+                const sts = new this.serverless.providers.aws.sdk.STS();
+                const { Account } = await sts.getCallerIdentity({}).promise();
+                return { [match]: Account };
+              case "#{AWS::Partition}":
+                if (/^us\-gov/.test(region)) {
+                  return { [match]: "aws-us-gov" };
+                } else if (/^cn\-/.test(region)) {
+                  return { [match]: "aws-cn" };
+                }
+                return { [match]: "aws" };
+              case "#{AWS::NoValue}":
+                return { [match]: undefined };
+              case "#{AWS::StackName}":
+                return {
+                  [match]: this.serverless.providers.aws.naming.getStackName(),
+                };
+              case "#{AWS::StackId}":
+                const cloudformation = new this.serverless.providers.aws.sdk.CloudFormation(
+                  { region }
+                );
+                let nextTokenListStacks;
+                let stackId;
+                do {
+                  const {
+                    StackSummaries,
+                    NextToken,
+                  } = await cloudformation
+                    .listStacks({ NextToken: nextTokenListStacks })
+                    .promise();
+                  const stackSummary = StackSummaries.find(
+                    ({ StackName }) =>
+                      StackName ===
+                      this.serverless.providers.aws.naming.getStackName()
+                  );
+                  if (stackSummary) {
+                    nextTokenListStacks = null;
+                    stackId = stackSummary.StackId;
+                  } else {
+                    nextTokenListStacks = NextToken;
+                  }
+                } while (nextTokenListStacks);
+                return {
+                  [match]: stackId,
+                };
+              case "#{AWS::URLSuffix}":
+                if (/^cn\-/.test(region)) {
+                  return { [match]: "amazonaws.com.cn" };
+                }
+                return { [match]: "amazonaws.com" };
+              default:
+                return { [match]: match };
+            }
+          })
+      )
+    ).reduce((acc, item) => Object.assign(acc, item), {});
+
+    // replace matches and return resolved object
+    return JSON.parse(
+      stringifiedFunctionObject.replace(
+        this.awsRegex(this.allowReferences),
+        (match) => resolvedVariables[match]
+      )
+    );
+  }
+
+  async invokeLocal() {
+    // merge resolved environmental variables system environmental variables
+    Object.assign(
+      process.env,
+      (await this.runtimeResolveAWSVariables()).environment
+    );
+  }
+
+  async deployFunction() {
+    // merge resolved variables to function object
+    Object.assign(
+      this.serverless.processedInput.options.functionObj,
+      await this.runtimeResolveAWSVariables()
+    );
+  }
+
+  addParameters() {
+    const template = this.serverless.service.provider
+      .compiledCloudFormationTemplate;
     const skipRegionReplace = this.skipRegionReplace;
     const allowReferences = this.allowReferences;
     const colors = this.colors;
     const debug = this.debug;
     const consoleLog = this.serverless.cli.consoleLog;
+    const awsRegex = this.awsRegex;
 
-    if (debug) consoleLog(yellow(underline('AWS Pseudo Parameters')));
+    if (debug) consoleLog(yellow(underline("AWS Pseudo Parameters")));
 
     if (skipRegionReplace && debug) {
-      consoleLog('Skipping automatic replacement of regions with account region!');
+      consoleLog(
+        "Skipping automatic replacement of regions with account region!"
+      );
     }
 
     // loop through the entire template, and check all (string) properties for any #{AWS::}
     // reference. If found, replace the value with an Fn::Sub reference
-    Object.keys(template).forEach(identifier => {
+    Object.keys(template).forEach((identifier) => {
       replaceChildNodes(template[identifier], identifier);
     });
 
-
     function isDict(v) {
-      return typeof v === 'object' && v !== null && !(v instanceof Array) && !(v instanceof Date);
+      return (
+        typeof v === "object" &&
+        v !== null &&
+        !(v instanceof Array) &&
+        !(v instanceof Date)
+      );
     }
 
     function isArray(v) {
-      return Object.prototype.toString.call(v) === '[object Array]';
+      return Object.prototype.toString.call(v) === "[object Array]";
     }
 
     function regions() {
       return [
-        'ap-northeast-1',
-        'ap-northeast-2',
-        'ap-south-1',
-        'ap-southeast-1',
-        'ap-southeast-2',
-        'ca-central-1',
-        'eu-central-1',
-        'eu-west-1',
-        'eu-west-2',
-        'eu-west-3',
-        'sa-east-1',
-        'us-east-1',
-        'us-east-2',
-        'us-west-1',
-        'us-west-2'
+        "ap-northeast-1",
+        "ap-northeast-2",
+        "ap-south-1",
+        "ap-southeast-1",
+        "ap-southeast-2",
+        "ca-central-1",
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-2",
+        "eu-west-3",
+        "sa-east-1",
+        "us-east-1",
+        "us-east-2",
+        "us-west-1",
+        "us-west-2",
       ];
     }
 
     function containsRegion(v) {
-      return new RegExp(regions().join('|')).test(v);
+      return new RegExp(regions().join("|")).test(v);
     }
 
     function replaceChildNodes(dictionary, name) {
       Object.keys(dictionary).forEach((key) => {
-
         let value = dictionary[key];
         // if a region name is mentioned, replace it with a reference (unless we are skipping automatic replacements)
-        if (typeof value === 'string' && !skipRegionReplace && containsRegion(value)) {
-          const regionFinder = new RegExp(regions().join('|'));
-          value = value.replace(regionFinder, '#{AWS::Region}');
+        if (
+          typeof value === "string" &&
+          !skipRegionReplace &&
+          containsRegion(value)
+        ) {
+          const regionFinder = new RegExp(regions().join("|"));
+          value = value.replace(regionFinder, "#{AWS::Region}");
         }
 
-        var aws_regex;
-        if (allowReferences) {
-          aws_regex = /#{([^}]+)}/g;
-        } else {
-          aws_regex = /#{(AWS::[a-zA-Z]+)}/g;
-        }
+        const aws_regex = awsRegex(allowReferences);
 
         // we only want to possibly replace strings with an Fn::Sub
-        if (typeof value === 'string' && value.search(aws_regex) >= 0) {
+        if (typeof value === "string" && value.search(aws_regex) >= 0) {
+          let replacedString = value.replace(aws_regex, "${$1}");
 
-          let replacedString = value.replace(aws_regex, '${$1}');
-
-          if (key === 'Fn::Sub') {
+          if (key === "Fn::Sub") {
             dictionary[key] = replacedString;
           } else {
             dictionary[key] = {
-              'Fn::Sub': replacedString
+              "Fn::Sub": replacedString,
             };
           }
 
@@ -101,43 +230,54 @@ class ServerlessAWSPseudoParameters {
             // do some fancy logging
             let m = aws_regex.exec(value);
             while (m) {
-              consoleLog('AWS Pseudo Parameter: ' + name + '::' + key + ' Replaced ' + yellow(m[1]) + ' with ' + yellow(
-                '${' + m[1] + '}'));
+              consoleLog(
+                "AWS Pseudo Parameter: " +
+                  name +
+                  "::" +
+                  key +
+                  " Replaced " +
+                  yellow(m[1]) +
+                  " with " +
+                  yellow("${" + m[1] + "}")
+              );
               m = aws_regex.exec(value);
             }
           }
         }
 
-
         var escaped_regex = /#@{([^}]+)}/g;
-        if (typeof value === 'string' && value.search(escaped_regex) >= 0) {
-            let replacedString = value.replace(escaped_regex, '#{$1}');
-            dictionary[key] = replacedString;
+        if (typeof value === "string" && value.search(escaped_regex) >= 0) {
+          let replacedString = value.replace(escaped_regex, "#{$1}");
+          dictionary[key] = replacedString;
         }
 
         // dicts and arrays need to be looped through
         if (isDict(value) || isArray(value)) {
-          dictionary[key] = replaceChildNodes(value, name + '::' + key);
+          dictionary[key] = replaceChildNodes(value, name + "::" + key);
         }
-
       });
       return dictionary;
     }
 
     function yellow(str) {
-      if (colors) return '\u001B[33m' + str + '\u001B[39m';
+      if (colors) return "\u001B[33m" + str + "\u001B[39m";
       return str;
     }
 
     function underline(str) {
-      if (colors) return '\u001B[4m' + str + '\u001B[24m';
+      if (colors) return "\u001B[4m" + str + "\u001B[24m";
       return str;
     }
   }
 }
 
 function get(obj, path, def) {
-  return path.split('.').filter(Boolean).every(step => !(step && (obj = obj[step]) === undefined)) ? obj : def;
+  return path
+    .split(".")
+    .filter(Boolean)
+    .every((step) => !(step && (obj = obj[step]) === undefined))
+    ? obj
+    : def;
 }
 
 module.exports = ServerlessAWSPseudoParameters;

--- a/lib/index.js
+++ b/lib/index.js
@@ -29,18 +29,11 @@ class ServerlessAWSPseudoParameters {
     return allowReferences ? /#{([^}]+)}/g : /#{(AWS::[a-zA-Z]+)}/g;
   }
 
-  async runtimeResolveAWSVariables() {
-    const stringifiedFunctionObject = JSON.stringify(
-      this.serverless.processedInput.options.functionObj
-    );
+  async runtimeResolveAWSVariables(stringifiedParameters) {
     // Resolve parameters
     const resolvedVariables = (
       await Promise.all(
-        (
-          stringifiedFunctionObject.match(
-            this.awsRegex(this.allowReferences)
-          ) || []
-        )
+        (stringifiedParameters.match(this.awsRegex(this.allowReferences)) || [])
           .reduce((acc, match) => {
             if (!acc.includes(match)) {
               acc.push(match);
@@ -117,7 +110,7 @@ class ServerlessAWSPseudoParameters {
 
     // replace matches and return resolved object
     return JSON.parse(
-      stringifiedFunctionObject.replace(
+      stringifiedParameters.replace(
         this.awsRegex(this.allowReferences),
         (match) => resolvedVariables[match]
       )
@@ -126,17 +119,39 @@ class ServerlessAWSPseudoParameters {
 
   async invokeLocal() {
     // merge resolved environmental variables system environmental variables
+    const stringifiedProviderEnvironment = JSON.stringify(
+      this.serverless.service.provider.environment || {}
+    );
     Object.assign(
       process.env,
-      (await this.runtimeResolveAWSVariables()).environment
+      await this.runtimeResolveAWSVariables(stringifiedProviderEnvironment)
+    );
+    const stringifiedFunctionObjectEnvironment = JSON.stringify(
+      this.serverless.processedInput.options.functionObj.environment || {}
+    );
+    Object.assign(
+      process.env,
+      await this.runtimeResolveAWSVariables(
+        stringifiedFunctionObjectEnvironment
+      )
     );
   }
 
   async deployFunction() {
     // merge resolved variables to function object
+    const stringifiedProviderEnvironment = JSON.stringify(
+      this.serverless.service.provider.environment || {}
+    );
+    Object.assign(
+      this.serverless.service.provider.environment || {},
+      await this.runtimeResolveAWSVariables(stringifiedProviderEnvironment)
+    );
+    const stringifiedFunctionObject = JSON.stringify(
+      this.serverless.processedInput.options.functionObj
+    );
     Object.assign(
       this.serverless.processedInput.options.functionObj,
-      await this.runtimeResolveAWSVariables()
+      await this.runtimeResolveAWSVariables(stringifiedFunctionObject)
     );
   }
 

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -276,7 +276,10 @@ describe('Plugin', () => {
         },
         service: {
           provider: {
-            region: 'us-east-1'
+            region: 'us-east-1',
+            environment: {
+              ACCOUNT_ID_PROVIDER: 'my-#{AWS::AccountId}-provider'
+            }
           }
         }
       };
@@ -354,6 +357,7 @@ describe('Plugin', () => {
 
     it('resolves and merges #{AWS::[VAR]} parameters with system environmental variables on invoke local', async () => {
       await serverlessPseudoParamsPlugin.invokeLocal();
+      expect(process.env.ACCOUNT_ID_PROVIDER).toBe('my-012345678910-provider');
       expect(process.env.ACCOUNT_ID).toBe('my-012345678910');
       expect(process.env.REGION).toBe('my-us-east-1');
       expect(process.env.PARTITION).toBe('my-aws');
@@ -368,8 +372,13 @@ describe('Plugin', () => {
       );
     });
 
-    it('resolves and merges #{AWS::[VAR]} parameters with functionObj', async () => {
+    it('resolves and merges #{AWS::[VAR]} parameters on deployFunction', async () => {
       await serverlessPseudoParamsPlugin.deployFunction();
+      expect(
+        serverlessPseudoParamsPlugin.serverless.service.provider.environment
+      ).toEqual({
+        ACCOUNT_ID_PROVIDER: 'my-012345678910-provider'
+      });
       expect(
         serverlessPseudoParamsPlugin.serverless.processedInput.options
           .functionObj

--- a/lib/index.spec.js
+++ b/lib/index.spec.js
@@ -1,7 +1,6 @@
 const Plugin = require('.');
 
 describe('Plugin', () => {
-
   describe('Using pseudo parameters', () => {
     let serverlessPseudoParamsPlugin;
     let resultTemplate;
@@ -14,75 +13,109 @@ describe('Plugin', () => {
         },
         service: {
           provider: {
-            compiledCloudFormationTemplate: {},
+            compiledCloudFormationTemplate: {}
           }
-        },
+        }
       };
-      serverless.service.provider.compiledCloudFormationTemplate = { Resources: {
-        acmeResource: {
-          Type: "AWS::Foo::Bar",
-          Properties: {
-            AccountId: "#{AWS::AccountId}",
-            Region: "#{AWS::Region}",
-            NotificationARNs: "#{AWS::NotificationARNs}",
-            NoValue: "#{AWS::NoValue}",
-            Partition: "#{AWS::Partition}",
-            StackId: "#{AWS::StackId}",
-            StackName: "#{AWS::StackName}",
-            URLSuffix: "#{AWS::URLSuffix}",
-            Reference: "#{SomeResource}",
-            Substitution: {
-              "Fn::Sub": "#{SomeResource}"
-            },
-            Escaping: {
-              StringValue: "#@{myOutputS3Loc}/#@{format(@scheduledStartTime, 'YYYY-MM-dd-HH-mm-ss')}"
+      serverless.service.provider.compiledCloudFormationTemplate = {
+        Resources: {
+          acmeResource: {
+            Type: 'AWS::Foo::Bar',
+            Properties: {
+              AccountId: '#{AWS::AccountId}',
+              Region: '#{AWS::Region}',
+              NotificationARNs: '#{AWS::NotificationARNs}',
+              NoValue: '#{AWS::NoValue}',
+              Partition: '#{AWS::Partition}',
+              StackId: '#{AWS::StackId}',
+              StackName: '#{AWS::StackName}',
+              URLSuffix: '#{AWS::URLSuffix}',
+              Reference: '#{SomeResource}',
+              Substitution: {
+                'Fn::Sub': '#{SomeResource}'
+              },
+              Escaping: {
+                StringValue:
+                  "#@{myOutputS3Loc}/#@{format(@scheduledStartTime, 'YYYY-MM-dd-HH-mm-ss')}"
+              }
             }
           }
         }
-      } };
+      };
       serverlessPseudoParamsPlugin = new Plugin(serverless);
       serverlessPseudoParamsPlugin.serverless.service.service = 'foo-service';
       serverlessPseudoParamsPlugin.addParameters();
-      resultTemplate = serverlessPseudoParamsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
-      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(11);
+      resultTemplate =
+        serverlessPseudoParamsPlugin.serverless.service.provider
+          .compiledCloudFormationTemplate;
+      expect(
+        Object.keys(resultTemplate.Resources.acmeResource.Properties).length
+      ).toEqual(11);
     });
 
     it('replaces #{AWS::[VAR]} with the correct CF pseudo parameter', () => {
-      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(11);
+      expect(
+        Object.keys(resultTemplate.Resources.acmeResource.Properties).length
+      ).toEqual(11);
     });
 
     it('replaces #{AWS::AccountId} with the ${AWS::AccountId} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.AccountId).toEqual({ 'Fn::Sub': '${AWS::AccountId}' });
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.AccountId
+      ).toEqual({ 'Fn::Sub': '${AWS::AccountId}' });
     });
     it('replaces #{AWS::Region} with the ${AWS::Region} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.Region).toEqual({ 'Fn::Sub': '${AWS::Region}' });
+      expect(resultTemplate.Resources.acmeResource.Properties.Region).toEqual({
+        'Fn::Sub': '${AWS::Region}'
+      });
     });
     it('replaces #{AWS::NotificationARNs} with the ${AWS::NotificationARNs} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.NotificationARNs).toEqual({ 'Fn::Sub': '${AWS::NotificationARNs}' });
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.NotificationARNs
+      ).toEqual({ 'Fn::Sub': '${AWS::NotificationARNs}' });
     });
     it('replaces #{AWS::NoValue} with the ${AWS::NoValue} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.NoValue).toEqual({ 'Fn::Sub': '${AWS::NoValue}' });
+      expect(resultTemplate.Resources.acmeResource.Properties.NoValue).toEqual({
+        'Fn::Sub': '${AWS::NoValue}'
+      });
     });
     it('replaces #{AWS::Partition} with the ${AWS::Partition} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.Partition).toEqual({ 'Fn::Sub': '${AWS::Partition}' });
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.Partition
+      ).toEqual({ 'Fn::Sub': '${AWS::Partition}' });
     });
     it('replaces #{AWS::StackId} with the ${AWS::StackId} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.StackId).toEqual({ 'Fn::Sub': '${AWS::StackId}' });
+      expect(resultTemplate.Resources.acmeResource.Properties.StackId).toEqual({
+        'Fn::Sub': '${AWS::StackId}'
+      });
     });
     it('replaces #{AWS::StackName} with the ${AWS::StackName} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.StackName).toEqual({ 'Fn::Sub': '${AWS::StackName}' });
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.StackName
+      ).toEqual({ 'Fn::Sub': '${AWS::StackName}' });
     });
     it('replaces #{AWS::URLSuffix} with the ${AWS::URLSuffix} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.URLSuffix).toEqual({ 'Fn::Sub': '${AWS::URLSuffix}' });
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.URLSuffix
+      ).toEqual({ 'Fn::Sub': '${AWS::URLSuffix}' });
     });
     it('replaces #{SomeResource}', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.Reference).toEqual({ 'Fn::Sub': '${SomeResource}'});
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.Reference
+      ).toEqual({ 'Fn::Sub': '${SomeResource}' });
     });
     it('should not add Fn::Sub to items with Fn::Sub already', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.Substitution).toEqual({ 'Fn::Sub': '${SomeResource}'});
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.Substitution
+      ).toEqual({ 'Fn::Sub': '${SomeResource}' });
     });
     it('should not replace escaped items', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.Escaping).toEqual({ 'StringValue': '#{myOutputS3Loc}/#{format(@scheduledStartTime, \'YYYY-MM-dd-HH-mm-ss\')}'});
+      expect(resultTemplate.Resources.acmeResource.Properties.Escaping).toEqual(
+        {
+          StringValue:
+            "#{myOutputS3Loc}/#{format(@scheduledStartTime, 'YYYY-MM-dd-HH-mm-ss')}"
+        }
+      );
     });
   });
 
@@ -98,42 +131,53 @@ describe('Plugin', () => {
         },
         service: {
           provider: {
-            compiledCloudFormationTemplate: {},
+            compiledCloudFormationTemplate: {}
           },
           custom: {
             pseudoParameters: {
               allowReferences: true
             }
           }
-        },
+        }
       };
-      serverless.service.provider.compiledCloudFormationTemplate = { Resources: {
-        acmeResource: {
-          Type: "AWS::Foo::Bar",
-          Properties: {
-            AccountId: "#{AWS::AccountId}",
-            Reference: "#{SomeResource}",
+      serverless.service.provider.compiledCloudFormationTemplate = {
+        Resources: {
+          acmeResource: {
+            Type: 'AWS::Foo::Bar',
+            Properties: {
+              AccountId: '#{AWS::AccountId}',
+              Reference: '#{SomeResource}'
+            }
           }
         }
-      } };
+      };
       serverlessPseudoParamsPlugin = new Plugin(serverless);
       serverlessPseudoParamsPlugin.serverless.service.service = 'foo-service';
       serverlessPseudoParamsPlugin.addParameters();
-      resultTemplate = serverlessPseudoParamsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
-      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(2);
+      resultTemplate =
+        serverlessPseudoParamsPlugin.serverless.service.provider
+          .compiledCloudFormationTemplate;
+      expect(
+        Object.keys(resultTemplate.Resources.acmeResource.Properties).length
+      ).toEqual(2);
     });
 
     it('replaces #{AWS::[VAR]} with the correct CF pseudo parameter', () => {
-      expect(Object.keys(resultTemplate.Resources.acmeResource.Properties).length).toEqual(2);
+      expect(
+        Object.keys(resultTemplate.Resources.acmeResource.Properties).length
+      ).toEqual(2);
     });
 
     it('replaces #{AWS::AccountId} with the ${AWS::AccountId} pseudo parameter', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.AccountId).toEqual({ 'Fn::Sub': '${AWS::AccountId}' });
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.AccountId
+      ).toEqual({ 'Fn::Sub': '${AWS::AccountId}' });
     });
     it('replaces #{SomeResource} with ${SomeResource}', () => {
-      expect(resultTemplate.Resources.acmeResource.Properties.Reference).toEqual({ 'Fn::Sub': '${SomeResource}' });
+      expect(
+        resultTemplate.Resources.acmeResource.Properties.Reference
+      ).toEqual({ 'Fn::Sub': '${SomeResource}' });
     });
-
   });
 
   describe('using pseudo parameters in the outputs', () => {
@@ -148,26 +192,30 @@ describe('Plugin', () => {
         },
         service: {
           provider: {
-            compiledCloudFormationTemplate: {},
+            compiledCloudFormationTemplate: {}
           }
-        },
-      };
-      serverless.service.provider.compiledCloudFormationTemplate = { Outputs: {
-        acmeOutput: {
-          AccountId: "#{AWS::AccountId}",
-          Region: "#{AWS::Region}",
-          NotificationARNs: "#{AWS::NotificationARNs}",
-          NoValue: "#{AWS::NoValue}",
-          Partition: "#{AWS::Partition}",
-          StackId: "#{AWS::StackId}",
-          StackName: "#{AWS::StackName}",
-          URLSuffix: "#{AWS::URLSuffix}",
         }
-      } };
+      };
+      serverless.service.provider.compiledCloudFormationTemplate = {
+        Outputs: {
+          acmeOutput: {
+            AccountId: '#{AWS::AccountId}',
+            Region: '#{AWS::Region}',
+            NotificationARNs: '#{AWS::NotificationARNs}',
+            NoValue: '#{AWS::NoValue}',
+            Partition: '#{AWS::Partition}',
+            StackId: '#{AWS::StackId}',
+            StackName: '#{AWS::StackName}',
+            URLSuffix: '#{AWS::URLSuffix}'
+          }
+        }
+      };
       serverlessPseudoParamsPlugin = new Plugin(serverless);
       serverlessPseudoParamsPlugin.serverless.service.service = 'foo-service';
       serverlessPseudoParamsPlugin.addParameters();
-      resultTemplate = serverlessPseudoParamsPlugin.serverless.service.provider.compiledCloudFormationTemplate;
+      resultTemplate =
+        serverlessPseudoParamsPlugin.serverless.service.provider
+          .compiledCloudFormationTemplate;
       expect(Object.keys(resultTemplate.Outputs.acmeOutput).length).toEqual(8);
     });
 
@@ -176,31 +224,176 @@ describe('Plugin', () => {
     });
 
     it('replaces #{AWS::AccountId} with the ${AWS::AccountId} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.AccountId).toEqual({ 'Fn::Sub': '${AWS::AccountId}' });
+      expect(resultTemplate.Outputs.acmeOutput.AccountId).toEqual({
+        'Fn::Sub': '${AWS::AccountId}'
+      });
     });
     it('replaces #{AWS::Region} with the ${AWS::Region} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.Region).toEqual({ 'Fn::Sub': '${AWS::Region}' });
+      expect(resultTemplate.Outputs.acmeOutput.Region).toEqual({
+        'Fn::Sub': '${AWS::Region}'
+      });
     });
     it('replaces #{AWS::NotificationARNs} with the ${AWS::NotificationARNs} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.NotificationARNs).toEqual({ 'Fn::Sub': '${AWS::NotificationARNs}' });
+      expect(resultTemplate.Outputs.acmeOutput.NotificationARNs).toEqual({
+        'Fn::Sub': '${AWS::NotificationARNs}'
+      });
     });
     it('replaces #{AWS::NoValue} with the ${AWS::NoValue} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.NoValue).toEqual({ 'Fn::Sub': '${AWS::NoValue}' });
+      expect(resultTemplate.Outputs.acmeOutput.NoValue).toEqual({
+        'Fn::Sub': '${AWS::NoValue}'
+      });
     });
     it('replaces #{AWS::Partition} with the ${AWS::Partition} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.Partition).toEqual({ 'Fn::Sub': '${AWS::Partition}' });
+      expect(resultTemplate.Outputs.acmeOutput.Partition).toEqual({
+        'Fn::Sub': '${AWS::Partition}'
+      });
     });
     it('replaces #{AWS::StackId} with the ${AWS::StackId} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.StackId).toEqual({ 'Fn::Sub': '${AWS::StackId}' });
+      expect(resultTemplate.Outputs.acmeOutput.StackId).toEqual({
+        'Fn::Sub': '${AWS::StackId}'
+      });
     });
     it('replaces #{AWS::StackName} with the ${AWS::StackName} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.StackName).toEqual({ 'Fn::Sub': '${AWS::StackName}' });
+      expect(resultTemplate.Outputs.acmeOutput.StackName).toEqual({
+        'Fn::Sub': '${AWS::StackName}'
+      });
     });
     it('replaces #{AWS::URLSuffix} with the ${AWS::URLSuffix} pseudo parameter', () => {
-      expect(resultTemplate.Outputs.acmeOutput.URLSuffix).toEqual({ 'Fn::Sub': '${AWS::URLSuffix}' });
+      expect(resultTemplate.Outputs.acmeOutput.URLSuffix).toEqual({
+        'Fn::Sub': '${AWS::URLSuffix}'
+      });
     });
-  })
+  });
 
+  describe('using pseudo parameters with runtime hooks', () => {
+    let serverlessPseudoParamsPlugin;
 
+    beforeEach(() => {
+      const serverless = {
+        cli: {
+          log: () => {},
+          consoleLog: () => {}
+        },
+        service: {
+          provider: {
+            region: 'us-east-1'
+          }
+        }
+      };
+      serverless.providers = {
+        aws: {
+          naming: {
+            getStackName: () => 'foo-service-dev'
+          },
+          sdk: {
+            STS: jest.fn().mockImplementation(() => ({
+              getCallerIdentity: () => ({
+                promise: () => ({
+                  Account: '012345678910'
+                })
+              })
+            })),
+            CloudFormation: jest.fn().mockImplementation(() => ({
+              listStacks: () => ({
+                promise: () => ({
+                  StackSummaries: [
+                    {
+                      StackName: 'foo-service-dev',
+                      StackId:
+                        'arn:aws:cloudformation:us-east-1:012345678910:stack/foo-service-dev/90239860-ef77-11ea-8ae8-0e29088293c9'
+                    }
+                  ]
+                })
+              })
+            }))
+          }
+        }
+      };
+      serverless.service.functions = {
+        foo: {
+          handler: 'index.handler',
+          environment: {
+            ACCOUNT_ID: 'my-#{AWS::AccountId}',
+            REGION: 'my-#{AWS::Region}',
+            PARTITION: 'my-#{AWS::Partition}',
+            STACK_ID: 'my-#{AWS::StackId}',
+            STACK_NAME: 'my-#{AWS::StackName}',
+            URL_SUFFIX: 'my-#{AWS::URLSuffix}',
+            NOTHING: 'my-nothing'
+          },
+          name: 'foo-service-dev-foo'
+        }
+      };
+      serverlessPseudoParamsPlugin = new Plugin(serverless);
+      serverlessPseudoParamsPlugin.serverless.service.service = 'foo-service';
+      serverless.processedInput = {
+        options: {
+          functionObj: {
+            handler: 'index.handler',
+            environment: {
+              ACCOUNT_ID: 'my-#{AWS::AccountId}',
+              REGION: 'my-#{AWS::Region}',
+              PARTITION: 'my-#{AWS::Partition}',
+              STACK_ID: 'my-#{AWS::StackId}',
+              STACK_NAME: 'my-#{AWS::StackName}',
+              URL_SUFFIX: 'my-#{AWS::URLSuffix}',
+              NOTHING: 'my-nothing',
+              ALL:
+                'my-#{AWS::AccountId}-#{AWS::Region}-#{AWS::Partition}-#{AWS::StackId}-#{AWS::StackName}-#{AWS::URLSuffix}'
+            },
+            events: [{ sns: 'topic-#{AWS::Region}' }],
+            name: 'foo-service-dev-foo'
+          }
+        }
+      };
+    });
 
+    afterAll(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('resolves and merges #{AWS::[VAR]} parameters with system environmental variables on invoke local', async () => {
+      await serverlessPseudoParamsPlugin.invokeLocal();
+      expect(process.env.ACCOUNT_ID).toBe('my-012345678910');
+      expect(process.env.REGION).toBe('my-us-east-1');
+      expect(process.env.PARTITION).toBe('my-aws');
+      expect(process.env.STACK_ID).toBe(
+        'my-arn:aws:cloudformation:us-east-1:012345678910:stack/foo-service-dev/90239860-ef77-11ea-8ae8-0e29088293c9'
+      );
+      expect(process.env.STACK_NAME).toBe('my-foo-service-dev');
+      expect(process.env.URL_SUFFIX).toBe('my-amazonaws.com');
+      expect(process.env.NOTHING).toBe('my-nothing');
+      expect(process.env.ALL).toBe(
+        'my-012345678910-us-east-1-aws-arn:aws:cloudformation:us-east-1:012345678910:stack/foo-service-dev/90239860-ef77-11ea-8ae8-0e29088293c9-foo-service-dev-amazonaws.com'
+      );
+    });
+
+    it('resolves and merges #{AWS::[VAR]} parameters with functionObj', async () => {
+      await serverlessPseudoParamsPlugin.deployFunction();
+      expect(
+        serverlessPseudoParamsPlugin.serverless.processedInput.options
+          .functionObj
+      ).toEqual({
+        environment: {
+          ACCOUNT_ID: 'my-012345678910',
+          ALL:
+            'my-012345678910-us-east-1-aws-arn:aws:cloudformation:us-east-1:012345678910:stack/foo-service-dev/90239860-ef77-11ea-8ae8-0e29088293c9-foo-service-dev-amazonaws.com',
+          NOTHING: 'my-nothing',
+          PARTITION: 'my-aws',
+          REGION: 'my-us-east-1',
+          STACK_ID:
+            'my-arn:aws:cloudformation:us-east-1:012345678910:stack/foo-service-dev/90239860-ef77-11ea-8ae8-0e29088293c9',
+          STACK_NAME: 'my-foo-service-dev',
+          URL_SUFFIX: 'my-amazonaws.com'
+        },
+        events: [
+          {
+            sns: 'topic-us-east-1'
+          }
+        ],
+        handler: 'index.handler',
+        name: 'foo-service-dev-foo'
+      });
+    });
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -3730,6 +3730,12 @@
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
     },
+    "prettier": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+      "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "24.9.0",
       "resolved": "http://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "serverless-pseudo-parameters",
   "version": "2.5.0",
   "devDependencies": {
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "prettier": "^2.1.1"
   },
   "license": "MIT",
   "repository": {
@@ -11,7 +12,8 @@
   },
   "scripts": {
     "test": "jest --env node",
-    "test:watch": "jest --env node --watch"
+    "test:watch": "jest --env node --watch",
+    "format": "prettier --write --ignore-path .gitignore '**/*.{css,html,js,json}'"
   },
   "main": "lib/index.js",
   "dependencies": {}


### PR DESCRIPTION
This PR adds support for `sls invoke local` and `sls deploy function` commands. AWS Pseudo Parameters are resolved in the runtime to the correct values and merged to corresponding objects.

fixes #18 
fixes #34 
fixes #55 

I also added prettier, because I was messing up the formatting all the time with my IDE autoformat 🤦 

And thanks for this plugin, we are hugely depending on this in our deployments.