### PR TITLE
 Improve Framework version check

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,15 +8,8 @@ class ServerlessAWSPseudoParameters {
     this.options = options || {};
     this.hooks = {
       initialize: () => {
-        const frameworkVersion = (() => {
-          try {
-            return require('serverless/package').version;
-          } catch (error) {
-            return null;
-          }
-        })();
-        if (!frameworkVersion) return;
-        if (!semver.gte(frameworkVersion, '2.50.0')) return;
+        if (!serverless.version) return;
+        if (!semver.gte(serverless.version, '2.50.0')) return;
         this.serverless.logDeprecation(
           'OBSOLETE_PSEUDO_PARAMETERS_PLUGIN',
           '"serverless-pseudo-parameters" plugin is no longer needed. Please uninstall it as it will not work with next Framework major release.\n' +


### PR DESCRIPTION
Initial implementation was unnecessary cumbersome, as Framework version can simply be retrieved from `serverless.version`
and checking that way will work in all cases, while previous implementation worked only if `serverless` was locally installed 